### PR TITLE
Make Cosinor functions applicable to 5 and 10 second epoch data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,10 +17,12 @@ Imports:
     cosinor2,
     dplyr,
     minpack.lm
+Suggests:
+    testthat
 Depends:
     R (>= 3.5.0),
 Encoding: UTF-8
 LazyData: true
 URL: https://github.com/junruidi/ActCR
 BugReports: https://github.com/junruidi/ActCR/issues
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 #Added new functions to derive metrics from extended cosinor models.
 
+10 Feb 2022
 
+#Cosinor models now able to handle time series with epoch length less than 1 minute
 
 

--- a/R/ActCosinor.R
+++ b/R/ActCosinor.R
@@ -28,7 +28,7 @@ ActCosinor = function(
   x,
   window = 1
 ){
-  if(1440 %% window != 0){
+  if (abs(1440 %% window) > 1e-12) {
     stop("Only use window size that is an integer factor of 1440")
   }
 

--- a/R/ActCosinor_long.R
+++ b/R/ActCosinor_long.R
@@ -7,7 +7,7 @@
 #' The first two columns have to be ID and Day. ID can be
 #' either \code{character} or \code{numeric}. Day has to be \code{numeric} indicating
 #' the sequence of days within each subject.
-#' @param window The calculation needs the window size of the data. E.g window = 1 means each epoch is in one-minute window.
+#' @param window The calculation needs the window size (unit minutes) of the data. E.g window = 1 means each epoch is in one-minute window.
 #'
 #' @importFrom stats na.omit reshape
 #' @importFrom dplyr group_by %>% do

--- a/R/ActExtendCosinor.R
+++ b/R/ActExtendCosinor.R
@@ -3,7 +3,7 @@
 #'
 #'
 #' @param x \code{vector} vector of dimension n*1440 which represents n days of 1440 minute activity data
-#' @param window The calculation needs the window size of the data. E.g window = 1 means each epoch is in one-minute window.
+#' @param window The calculation needs the window size (unit minutes) of the data. E.g window = 1 means each epoch is in one-minute window.
 #' @param lower A numeric vector of lower bounds on each of the five parameters (in the order of minimum, amplitude, alpha, beta, acrophase) for the NLS. If not given, the default lower bound for each parameter is set to \code{-Inf}.
 #' @param upper A numeric vector of upper bounds on each of the five parameters (in the order of minimum, amplitude, alpha, beta, acrophase) for the NLS. If not given, the default lower bound for each parameter is set to \code{Inf}
 #'
@@ -39,7 +39,7 @@ ActExtendCosinor = function(
   upper = c(Inf, Inf, 1, Inf, 27)
 
 ){
-  if(1440 %% window != 0){
+  if(abs(1440 %% window) > 1e-12) {
     stop("Only use window size that is an integer factor of 1440")
   }
 

--- a/man/ActCosinor_long.Rd
+++ b/man/ActCosinor_long.Rd
@@ -13,7 +13,7 @@ The first two columns have to be ID and Day. ID can be
 either \code{character} or \code{numeric}. Day has to be \code{numeric} indicating
 the sequence of days within each subject.}
 
-\item{window}{The calculation needs the window size of the data. E.g window = 1 means each epoch is in one-minute window.}
+\item{window}{The calculation needs the window size (unit minutes) of the data. E.g window = 1 means each epoch is in one-minute window.}
 }
 \value{
 A \code{data.frame} with the following 5 columns

--- a/man/ActExtendCosinor.Rd
+++ b/man/ActExtendCosinor.Rd
@@ -14,7 +14,7 @@ ActExtendCosinor(
 \arguments{
 \item{x}{\code{vector} vector of dimension n*1440 which represents n days of 1440 minute activity data}
 
-\item{window}{The calculation needs the window size of the data. E.g window = 1 means each epoch is in one-minute window.}
+\item{window}{The calculation needs the window size (unit minutes) of the data. E.g window = 1 means each epoch is in one-minute window.}
 
 \item{lower}{A numeric vector of lower bounds on each of the five parameters (in the order of minimum, amplitude, alpha, beta, acrophase) for the NLS. If not given, the default lower bound for each parameter is set to \code{-Inf}.}
 

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,3 @@
+library("testthat")
+library("ActCR")
+test_check("ActCR")

--- a/tests/testthat/test_CosinorFunctions.R
+++ b/tests/testthat/test_CosinorFunctions.R
@@ -1,0 +1,42 @@
+library(ActCR)
+context("ActCosinor and ActExtendCosinor")
+test_that("ActCosinor is consistent irrespective of epoch", {
+  skip_on_cran()
+
+  ActCosDummy = function(epochSizeSeconds) {
+    N = 1440 * (60 / epochSizeSeconds) # Number of epochs per day
+    time = seq(1 / N, 7, by = 1 / N)
+    counts = sin(time * 2 * pi) + 10
+    return(ActCosinor(x = counts, window = 1440 / N))
+  }
+
+  coef5 = ActCosDummy(epochSizeSeconds = 5)
+  coef60 = ActCosDummy(epochSizeSeconds = 60)
+  coef300 = ActCosDummy(epochSizeSeconds = 300)
+
+  expect_equal(coef300, coef5)
+  expect_equal(coef5, coef60)
+})
+
+test_that("ActExtendCosinor is consistent irrespective of epoch", {
+  skip_on_cran()
+
+  ActExtCosDummy = function(epochSizeSeconds) {
+    N = 1440 * (60 / epochSizeSeconds) # Number of epochs per day
+    time = seq(1 / N, 7, by = 1 / N)
+    counts = sin(time * 2 * pi) + 10
+    return(ActExtendCosinor(x = counts, window = 1440 / N))
+  }
+
+  coef5 = ActExtCosDummy(epochSizeSeconds = 30)
+  coef60 = ActExtCosDummy(epochSizeSeconds = 60)
+  coef300 = ActExtCosDummy(epochSizeSeconds = 300)
+
+  # Varnames we expect to be consistent
+  varn = c("minimum", "amp", "alpha", "beta", "acrotime",
+                               "UpMesor", "DownMesor", "MESOR", "ndays")
+  expect_equal(round(unlist(coef300[varn]), digits = 3),
+               round(unlist(coef5[varn]), digits = 3))
+  expect_equal(round(unlist(coef5[varn]), digits = 3),
+               round(unlist(coef60[varn]), digits = 3))
+})

--- a/tests/testthat/test_CosinorFunctions.R
+++ b/tests/testthat/test_CosinorFunctions.R
@@ -32,11 +32,11 @@ test_that("ActExtendCosinor is consistent irrespective of epoch", {
   coef60 = ActExtCosDummy(epochSizeSeconds = 60)
   coef300 = ActExtCosDummy(epochSizeSeconds = 300)
 
-  # Varnames we expect to be consistent
+  # Vars we expect to be consistent at 1 decimal place
   varn = c("minimum", "amp", "alpha", "beta", "acrotime",
                                "UpMesor", "DownMesor", "MESOR", "ndays")
-  expect_equal(round(unlist(coef300[varn]), digits = 3),
-               round(unlist(coef5[varn]), digits = 3))
-  expect_equal(round(unlist(coef5[varn]), digits = 3),
-               round(unlist(coef60[varn]), digits = 3))
+  expect_equal(round(unlist(coef300[varn]), digits = 1),
+               round(unlist(coef5[varn]), digits = 1))
+  expect_equal(round(unlist(coef5[varn]), digits = 1),
+               round(unlist(coef60[varn]), digits = 1))
 })

--- a/tests/testthat/test_CosinorFunctions.R
+++ b/tests/testthat/test_CosinorFunctions.R
@@ -28,7 +28,7 @@ test_that("ActExtendCosinor is consistent irrespective of epoch", {
     return(ActExtendCosinor(x = counts, window = 1440 / N))
   }
 
-  coef5 = ActExtCosDummy(epochSizeSeconds = 30)
+  coef5 = ActExtCosDummy(epochSizeSeconds = 5)
   coef60 = ActExtCosDummy(epochSizeSeconds = 60)
   coef300 = ActExtCosDummy(epochSizeSeconds = 300)
 


### PR DESCRIPTION
This PR aims to make functions ActCosinor and ActExtendCosinor applicable to data with epoch lengths less than 1 minute, e.g. 5 seconds. Currently, 5 second epoch data will cause `1440 %% as.numeric(1/12) != 0` to evaluate to TRUE and trigger `stop("Only use window size that is an integer factor of 1440")`. 

This is not because 5 seconds does not fit an integer number of times in 1440, but because machine precision cannot handle 1/12 minute very well. Same problem applies to 10 second epoch data (1/6 minute). By revising the code to `abs(1440 %% window) > 1e-12` I am addressing this.

As part of this PR you will find:
- Above modification to functions ActCosinor and ActExtendCosinor
- New unit tests to demonstrate that function output is consistent across epoch lengths given a simple sine as input.
- Documentation updated with clarification that argument window should be specified in minutes

Context: If it is possible to integrate this PR in ActCR it will be easier for me to add ActCR as a dependency to GGIR: https://github.com/wadpac/GGIR/issues/507, because GGIR users may prefer to work with 5 second data or at least have the option to compare role of epoch length on estimates.